### PR TITLE
Removed old link

### DIFF
--- a/posts/faq/block-rewards.md
+++ b/posts/faq/block-rewards.md
@@ -5,11 +5,7 @@ category: mining
 
 ## 0. Only Trust the Source
 
-The source code, and not this file, is the only true definiton of the block rewards. That source file is located here:
-
-[https://github.com/lbryio/lbrycrd/blob/real2/src/main.cpp](https://github.com/lbryio/lbrycrd/blob/real2/src/main.cpp#L1576)
-
-But is soon to be located in [`master`]:
+The source code, and not this file, is the only true definiton of the block rewards. That source file is located here in [`master`]:
 
 [https://github.com/lbryio/lbrycrd/blob/master/src/main.cpp](https://github.com/lbryio/lbrycrd/blob/master/src/main.cpp#L1576)
 


### PR DESCRIPTION
Removed the old link in FAQ:Block-Rewards as that is not working anymore due to changes.