### PR TITLE
always send headers, tweak header functions

### DIFF
--- a/controller/Controller.class.php
+++ b/controller/Controller.class.php
@@ -21,25 +21,26 @@ class Controller
         throw new Exception('use response::setheader instead of returning headers');
       }
 
-      if ($viewTemplate === null)
-      {
-        return;
-      }
-
       if (!$viewTemplate)
       {
-        throw new LogicException('All execute methods must return a template or NULL.');
+        if ($viewTemplate !== null)
+        {
+          throw new LogicException('All execute methods must return a template or NULL.');
+        }
+      }
+      else
+      {
+        $layout = !(isset($viewParameters['_no_layout']) && $viewParameters['_no_layout']);
+        unset($viewParameters['_no_layout']);
+
+        $layoutParams = $viewParameters[View::LAYOUT_PARAMS] ?? [];
+        unset($viewParameters[View::LAYOUT_PARAMS]);
+
+        $content = View::render($viewTemplate, $viewParameters + ['fullPage' => true]);
+
+        Response::setContent($layout ? View::render('layout/basic', ['content' => $content] + $layoutParams) : $content);
       }
 
-      $layout = !(isset($viewParameters['_no_layout']) && $viewParameters['_no_layout']);
-      unset($viewParameters['_no_layout']);
-
-      $layoutParams = $viewParameters[View::LAYOUT_PARAMS] ?? [];
-      unset($viewParameters[View::LAYOUT_PARAMS]);
-
-      $content = View::render($viewTemplate, $viewParameters + ['fullPage' => true]);
-
-      Response::setContent($layout ? View::render('layout/basic', ['content' => $content] + $layoutParams) : $content);
       Response::setDefaultSecurityHeaders();
       if (Request::isGzipAccepted())
       {

--- a/view/Response.class.php
+++ b/view/Response.class.php
@@ -169,12 +169,17 @@ class Response
 
   public static function setDownloadHttpHeaders($name, $type = null, $size = null, $noSniff = true)
   {
+    static::setBinaryHttpHeaders($type, $size, $noSniff);
+    static::setHeader('Content-Disposition', 'attachment;filename=' . $name);
+  }
+
+  public static function setBinaryHttpHeaders($type, $size = null, $noSniff = true)
+  {
     static::setGzipResponseContent(false); // in case its already compressed
     static::setHeaders(array_filter([
-      'Content-Disposition'    => 'attachment;filename=' . $name,
-      'Content-Type'           => $type ? 'application/zip' : null,
-      'Content-Length'         => $size ?: null,
-      'X-Content-Type-Options' => $noSniff ? 'nosniff' : null,
+      static::HEADER_CONTENT_TYPE => $type,
+      static::HEADER_CONTENT_LENGTH => $size ?: null,
+      static::HEADER_CONTENT_TYPE_OPTIONS => $noSniff ? 'nosniff' : null,
     ]));
   }
 


### PR DESCRIPTION
Main reason this is a PR is because headers weren't previous sent on actions that return null, which is difficult to inspect. I'd expect this isn't an issue, but wanted your approval. Also fixed a flipped (incorrect) ternary statement for download headers.