### PR TITLE
Updated with the correct place to find the wallet

### DIFF
--- a/content/faq/how-to-backup-wallet.md
+++ b/content/faq/how-to-backup-wallet.md
@@ -9,7 +9,7 @@ LBRY provides two different wallets, `lbryum` and `lbrycrd`. `lbryum` is the def
 
 #### Manually
 
-Make a copy of `~/.lbryum/default_wallet`.
+Make a copy of `~/.lbryum/wallets/default_wallet`.
 
 ### Backup `lbrycrd` wallet
 


### PR DESCRIPTION
Updates/change the locations from the old non existing default_wallet in lbryum Main dir to wallets/default_wallet.