### PR TITLE
file_path in publish example consistency

### DIFF
--- a/view/template/developer/_quickstartCredits.php
+++ b/view/template/developer/_quickstartCredits.php
@@ -17,7 +17,7 @@
 <p>Not sure what to publish? We recommend your favorite picture or home video. Or just grab something from <a class="link-primary" href="https://archive.org/details/movies">here</a>.</p>
 <code class="code-bash"><span class="code-bash__prompt">$</span>curl 'http://localhost:5279/lbryapi' --data '{"method":"publish", "params": {
   "name": "electricsheep",
-  "file_path": "\\home\kauffj\\Desktop\\electric-sheep.mp4",
+  "file_path": "/home/kauffj/Desktop/electric-sheep.mp4",
   "bid": 1,
   "metadata":  {
     "description": "Some interesting content",


### PR DESCRIPTION
The `file_path` in the publish example is now consistent with a path that would be used in a UNIX based system rather than some weird inconsistent Windows/Unix hybrid. Just an aesthetic change, really.