### PR TITLE
WIP: Docker development

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,16 @@ It's very easy to have lbry.io running locally:
 - Install PHP7
 - Checkout the project
 - Run `./dev.sh` from the project root
-- Access `localhost:8000` in your browser
+- Access [localhost:8000](http://localhost:8000) in your browser
+
+You can also run the development server using docker:
+
+- Install Docker
+- Checkout the project
+- Run `./dev-docker.sh` from the project root
+- Access [localhost:8000](http://localhost:8000) in your browser
+
+Both the `dev.sh` and `dev-docker.sh` scripts will initialise a configuration based on `data/config.php.example` if `data/config.php` does not exist.
 
 To run remotely, simply install PHP and configure Apache or your server of choice to serve `web/index.php`.
 

--- a/data/config.php.example
+++ b/data/config.php.example
@@ -1,0 +1,2 @@
+<?php
+return array();

--- a/data/config.php.example
+++ b/data/config.php.example
@@ -1,2 +1,14 @@
 <?php
-return array();
+$config = array();
+
+// $config['github_key'] = '';
+// $config['github_developer_credits_client_id'] = '';
+// $config['github_developer_credits_client_secret'] = '';
+// $config['lbry_api_server'] = '';
+// $config['mailchimp_key'] = '';
+// $config['prefinery_key'] = '';
+// $config['asana_key'] = '';
+// $config['aws_log_access_key'] = '';
+// $config['aws_log_secret_key'] = '';
+
+return $config;

--- a/dev-docker.sh
+++ b/dev-docker.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source dev-prepare.sh
+
+docker run --rm -it --name "dev.lbry.io" \
+  -v "$(readlink -f .):/usr/src/lbry.io" \
+  -w "/usr/src/lbry.io" \
+  -p "127.0.0.1:8000:8000" \
+  -u "$(id -u):$(id -g)" \
+  php:7-alpine \
+  php --server "0.0.0.0:8000" --docroot "web/" "web/index.php"

--- a/dev-prepare.sh
+++ b/dev-prepare.sh
@@ -1,0 +1,3 @@
+if [ ! -e "data/config.php" ]; then
+  cp "data/config.php.example" "data/config.php"
+fi

--- a/dev.sh
+++ b/dev.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+if [ ! -e "data/config.php" ]; then
+  cp "data/config.php.example" "data/config.php"
+fi
+
 php7.0 --server localhost:8000 --docroot web/ web/index.php

--- a/dev.sh
+++ b/dev.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [ ! -e "data/config.php" ]; then
-  cp "data/config.php.example" "data/config.php"
-fi
+source dev-prepare.sh
 
 php7.0 --server localhost:8000 --docroot web/ web/index.php


### PR DESCRIPTION
**TL;DR:** Added a `docker-dev.sh` which replicates the behavior of `dev.sh` but instead using Docker on the host, rather than PHP.

The first commit adds initialisation of `data/config.php` if it does not already exist. I included this as a separate commit so that it can be cherry-picked if you only want that change. A `data/config.php.example` file has been provided which in this iteration is extremely bare - it does the minimum to get the site running. If there are any other configurations that should be set for the basic development environment then these can be added although it may be the case that the expected defaults for a development environment should be set in the code as the default when calling `Config::get(key, default)`.

If not documented elsewhere then it may be worth using the `config.php.example` to leave commented out but documented configurations so there is a clear idea of what configurations _can_ be set and what they do. If this documentation is provided elsewhere a comment can be added to the example with a link to this resource.

The second commit provides a `dev-docker.sh` script which essentially does what `dev.sh` does but uses Docker instead using the `php:7-alpine` [image](https://hub.docker.com/_/php/) meaning that a developer can use Docker rather than installing the specific PHP version onto their host machine. Using docker also provides an isolated reproducible environment which should be the same regardless of whether the developer is using Linux, MacOS or Windows. I have not tested that the `dev-prepare.sh` works on Windows in any capacity - if anything doesn't work, it will probably be the `id` commands used.

I have set up the `dev-docker.sh` to map the working directory as a volume into the container so that changes are seen in real-time without rebuilding or re-running the script (as would happen using the existing `dev.sh` script). I have also configured it so that that the PHP server is only accessible on `localhost` (again matching `dev.sh` behaviour). Docker is run using the developer's UID and GID so that any files created are owned by the developer and will not require `sudo` elevation to edit or delete. The container that it creates is given the name "dev.lbry.io" and is set to delete itself once the container is stopped.

**There is a redundant `.gitkeep` in `data/` which can also be removed unless there is a reason to keep it?** It was redundant prior to these changes and so I have left it in place.

`dev-prepare.sh` can be extended to allow simple configurations of the development server including the ability to change which port the development server runs on.

Let me know of any changes you wish to be made.