### PR TITLE
Update log-to-console to reflect argument removal

### DIFF
--- a/content/faq/to-log-to-console.md
+++ b/content/faq/to-log-to-console.md
@@ -3,6 +3,4 @@ title: How can I see the log in the terminal?
 category: developer
 ---
 
-Run LBRY with the `--log-to-console` flag set:
-
-    lbrynet-daemon --log-to-console
+Simply run the daemon using `lbrynet-daemon` in a terminal. 

--- a/content/faq/to-log-to-console.md
+++ b/content/faq/to-log-to-console.md
@@ -3,4 +3,4 @@ title: How can I see the log in the terminal?
 category: developer
 ---
 
-Simply run the daemon using `lbrynet-daemon` in a terminal. 
+Simply run `lbry`, or the daemon `lbrynet-daemon`, in a terminal. 


### PR DESCRIPTION
Since [this commit](https://github.com/lbryio/lbry/commit/8fc6feb31646fe65dc0f857cb22e3b9c95e12c10), the argument no longer exists and logging to the terminal is done by default