### PR TITLE
reilly edits

### DIFF
--- a/content/faq/youtube.md
+++ b/content/faq/youtube.md
@@ -3,12 +3,4 @@ title: What is YouTube Sync?
 category: publisher
 order: 4
 ---
-The YouTube Sync process available within the [LBRY app](https://lbry.io/get) serves two purposes: 1) Allow YouTubers to qualify for [LBRY Rewards](https://lbry.io/faq/rewards) 2) Collect your YouTube channel information so LBRY can mirror your YouTube videos onto the LBRY network. Part 2 is is still undergoing development, so unless we reach out to you directly, your content will not be mirrored automatically. You are encouraged to [claim your channel and publish content](https://lbry.io/faq/how-to-publish) to LBRY directly through the app.   
-
-### What are the minimum requirements to be eligible for Rewards?
-Your YouTube channel must have at least 10 videos and 30,000 views to be eligible for [LBRY Rewards]((https://lbry.io/faq/rewards)). If it does not, please use one of the other [verification options](https://lbry.io/faq/identity-requirements).
-
-### I've met the requirements but I'm still not eligible for Rewards, help! 
-First, make sure you've restarted the LBRY app completely after linking your YouTube account. Press Ctrl-Q to quit or right click the system tray icon and then restart LBRY. If LBRY opens directly to the Home page without seeing the green loading screen, it means it is still running in the background. 
-
-If that does not fix it, please see our [help page](https://lbry.io/faq/how-to-report-bugs) to contact us. Include the YouTube channel name and LBRY connected email with your request.  
+The YouTube Sync process available within the [LBRY app](https://lbry.io/get) allows you to automatically mirror your existing YouTube channel onto the LBRY network. It is a free service for YouTubers not yet ready to go full-time on LBRY as a publisher but still want to make their content available for LBRY users. For the enterprising independent publisher, you are encouraged to [claim your channel and publish content](https://lbry.io/faq/how-to-publish) to LBRY directly through the app and master the LBRY App yourself, without using YouTube Sync.


### PR DESCRIPTION
I want the rewards out of YouTube sync. It has no place here and confuses the purpose of YouTube sync to the reader, which is to save a publisher labor if they have hundreds of archival videos. YouTube Sync is not about rewards, and we need to stop making it part of rewards verification.