### PR TITLE
Add github id to team page

### DIFF
--- a/content/bio/jeremy-kauffman.md
+++ b/content/bio/jeremy-kauffman.md
@@ -2,6 +2,7 @@
 name: Jeremy Kauffman
 role: Founder, Chief Executive Officer
 email: jeremy@lbry.io
+github: kauffj
 ---
 
 Jeremy knows how to build and scale a startup starting from day one. He knows how to deliver usable products and get those products in front of the right people.

--- a/view/template/content/_bio.php
+++ b/view/template/content/_bio.php
@@ -8,6 +8,9 @@
       <?php if (isset($email)): ?>
         <a href="mailto:<?php echo $email ?>" class="link-primary"><span class="icon icon-envelope"></span></a>
       <?php endif ?>
+      <?php if (isset ($github)): ?>
+        <a href="https://github.com/<?php echo $github ?>" class="link-primary"><span class="icon icon-github"></span></a>
+      <?php endif ?>
     </h4>
     <div class="meta spacer1"><?php echo $role ?></div>
     <div class="markdown">


### PR DESCRIPTION
As discussed in #325 add GitHub id for the team member.

I can only see 7 members in the organization page. Can someone confirm that everyone is there?
![screenshot from 2018-01-19 10-29-27](https://user-images.githubusercontent.com/7928135/35157990-adb4c818-fd03-11e7-8afa-3ef34a26a09c.png)
