### PR TITLE
Fixed Docker script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can also run the development server using docker:
 - Run `./docker.sh` from the project root
 - Access [localhost:8000](http://localhost:8000) in your browser
 
-Both the `dev.sh` and `dev-docker.sh` scripts will initialise a configuration based on `data/config.php.example` if `data/config.php` does not exist.
+Both the `dev.sh` and `docker.sh` scripts will initialise a configuration based on `data/config.php.example` if `data/config.php` does not exist.
 
 To run remotely, simply install PHP and configure Apache or your server of choice to serve `web/index.php`.
 

--- a/docker.sh
+++ b/docker.sh
@@ -3,14 +3,14 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 
-if [ ! -e "data/config.php" ]; then
+if [ ! -e "$DIR/data/config.php" ]; then
   cp "$DIR/data/config.php.example" "$DIR/data/config.php"
 fi
 
 docker run --rm -it --name "dev.lbry.io" \
-  -v "$(readlink -f .):/usr/src/lbry.io" \
+  -v "$DIR:/usr/src/lbry.io" \
   -w "/usr/src/lbry.io" \
   -p "127.0.0.1:8000:8000" \
   -u "$(id -u):$(id -g)" \
   php:7-alpine \
-  php --server "0.0.0.0:8000" --docroot "web/" "web/index.php"
+  php --server "0.0.0.0:8000" --docroot "web/" "index.php"


### PR DESCRIPTION
Updated the Docker script to start the site correctly. The DIR variable was not being used in each place which it should have been used and this has allowed the removal of the `readlink -f` command which had compatibility issues with MacOS (#297).

The README did not have the change in name for the docker script reflected in all references so this has also been corrected.

Note, this currently requires that `$config['is_prod'] = "yes";` is set in `data/config.php` due to #327 and the fact I currently have the script set to use the latest PHP 7 version (at present 7.2.1). Should you decide to specify a smaller subset of compatible PHP versions then I can update this PR to pin the docker version at either 7.0 or 7.1 depending on your preference.