### PR TITLE
dev.sh: Run `php` if there is no `php7.0` in PATH

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PHPBIN=php7.0
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 
@@ -7,4 +9,8 @@ if [ ! -e "data/config.php" ]; then
   cp "$DIR/data/config.php.example" "$DIR/data/config.php"
 fi
 
-php7.0 --server localhost:8000 --docroot "$DIR/web" "$DIR/web/index.php"
+if ! which $PHPBIN 2>/dev/null; then
+    PHPBIN=php
+fi
+
+$PHPBIN --server localhost:8000 --docroot "$DIR/web" "$DIR/web/index.php"


### PR DESCRIPTION
Resolves #357 