### PR TITLE
Add category filter for news post

### DIFF
--- a/controller/Controller.class.php
+++ b/controller/Controller.class.php
@@ -125,6 +125,7 @@ class Controller
     $router->any('/yt2', 'AcquisitionActions::executeYT2');
     $router->get('/verify/{token}', 'AcquisitionActions::executeVerify');
 
+    $router->get('/news/category/{category}', 'ContentActions::executePostCategoryFilter');
 
     $router->post('/set-culture', 'i18nActions::setCulture');
 

--- a/controller/action/ContentActions.class.php
+++ b/controller/action/ContentActions.class.php
@@ -364,4 +364,25 @@ class ContentActions extends Actions
       'posts' => array_slice(Post::find(static::VIEW_FOLDER_NEWS, Post::SORT_DATE_DESC), 0, $count)
     ];
   }
+  public static function executePostCategoryFilter(string $category)
+  {
+    Response::enableHttpCache();
+
+    $filter_post = [];
+
+    $posts = array_filter(
+      Post::find(static::VIEW_FOLDER_NEWS, Post::SORT_DATE_DESC),
+      function(Post $post) use ($category)  {
+        return (($post->getCategory() === $category) && (!$post->getDate() || $post->getDate()->format('U') <= date('U')));
+      });
+
+
+
+    return ['content/news', [
+      'posts'             => $posts,
+      View::LAYOUT_PARAMS => [
+        'showRssLink' => true
+      ]
+    ]];
+  }
 }


### PR DESCRIPTION
Fixes #290 

Missing frontend component for filtering and also category inside of the news content.