### PR TITLE
add redirect for /youtube/status/

### DIFF
--- a/controller/Controller.class.php
+++ b/controller/Controller.class.php
@@ -124,6 +124,7 @@ class Controller
     $router->post('/youtube/token', 'AcquisitionActions::executeYoutubeToken');
     $router->any('/youtube/status/{token}', 'AcquisitionActions::executeYoutubeStatus');
     $router->any('/youtube', 'AcquisitionActions::executeYouTube');
+    $router->any('/youtube/status', 'AcquisitionActions::executeRedirectYoutube');
 
     $router->get('/verify/{token}', 'AcquisitionActions::executeVerify');
 

--- a/controller/action/AcquisitionActions.class.php
+++ b/controller/action/AcquisitionActions.class.php
@@ -106,6 +106,10 @@ class AcquisitionActions extends Actions
     return ['acquisition/youtube_edit'];
   }
 
+  public static function executeRedirectYoutube(){
+      return ['acquisition/youtube_status_redirect'];
+  }
+
   protected static function email_verification($email)
   {
     if (preg_match('/\S+@\S+\.\S+/', $email)) {

--- a/view/template/acquisition/youtube_status_redirect.php
+++ b/view/template/acquisition/youtube_status_redirect.php
@@ -1,0 +1,11 @@
+<?php js_start() ?>
+if(localStorage.getItem('status_token')){
+    var status_token = localStorage.getItem('status_token');
+    url = '/youtube/status/' + status_token;
+    $(location).attr('href', url);
+}
+
+else{
+    $(location).attr('href', '/youtube');
+}
+<?php js_end() ?>


### PR DESCRIPTION
fix #479 

If the user type /youtube/status and has a valid status_token redirect to the token status page. if not then return to /youtube.