### PR TITLE
Custom SCSS File

### DIFF
--- a/web/scss/custom.scss
+++ b/web/scss/custom.scss
@@ -1,0 +1,13 @@
+//CUSTOM SCSS STYLES
+
+//News Page Custom Stlyes
+
+#news h3 {
+    text-transform: uppercase;
+    font-size: 1.2em;
+    line-height: 1.4em;
+    margin-bottom: 8px;
+}
+#news .meta {
+    color: #999;
+}


### PR DESCRIPTION
Added a **custom CSS** file for quick and easy customisation of specific areas.

News titles contained bad grammar, with mixed title case and non title case. To fix this, I made all titles capitalised.

I reduced the size, `line height` and `bottom-margin` of the **titles**, so that they were no too oversized thus easier to read, with more appearing within the window without scrolling and less dropping down on to the 2nd line.

Made the date and author text a little lighter to help separate it from the titles.

Added `@import "custom";` to `all.scss` to import this file.

Dependancies: #494 #497

![image](https://user-images.githubusercontent.com/29914179/38161199-896b13e4-350d-11e8-9ff7-3ba3af6c33c5.png)