### PR TITLE
Updated total amount credits in summary

### DIFF
--- a/content/credit-reports/2018-Q1.md
+++ b/content/credit-reports/2018-Q1.md
@@ -4,7 +4,7 @@ sheet: https://docs.google.com/spreadsheets/d/17GIrc-cmoXEY9x3NYhtxd45g2mHnuJ7cj
 category: policy
 ---
 ## Summary
-This quarter we moved no credits from cold storage.  We spent 393,525 total community credits on line items detailed below. No operational credits were moved to markets. No institutional credits were moved or spent.
+This quarter we moved no credits from cold storage.  We spent 393,585 total community credits on line items detailed below. No operational credits were moved to markets. No institutional credits were moved or spent.
 We anticipate comparable or larger total outlays in Q2 2018. Operational spending may increase, but not significantly, and community spending is likely to be higher. We will continue to incentivize new users and other beneficial behavior, which is likely to involve 500,000 to 3,000,000+ LBC. Additionally, LBRY has started a program for YouTubers that will scale up credit outlays. Finally, as it has now become de rigueur to state, no institutional outlays are expected, but a pilot program could happen.
 
 ## Overview By Fund


### PR DESCRIPTION
Updated 'We spent 393,525 total community credits on line items detailed below.' to 'We spent 393,585 total community credits on line items detailed below.' as the sum of the items below the summary is 393,585.