### PR TITLE
Mixed content weakens HTTPS fix 1

### DIFF
--- a/content/news/162-colinslaststand.md
+++ b/content/news/162-colinslaststand.md
@@ -8,7 +8,7 @@ This week, I’d like to reintroduce one of my personalities on LBRY.
 
 You caught Mr. Moriarty’s show Sidequest [in January](https://lbry.io/news/sidequest). Now it’s time for the main course.
 
-<video width="100%" controls poster="http://berk.ninja/thumbnails/2pI5sJU3lVI" src="https://spee.ch/9fcd6b485e8088908d84cd2f4c042ab7ce21a47f/the-coming-and-going-of-the-wild-west.mp4"/></video>
+<video width="100%" controls poster="https://berk.ninja/thumbnails/2pI5sJU3lVI" src="https://spee.ch/9fcd6b485e8088908d84cd2f4c042ab7ce21a47f/the-coming-and-going-of-the-wild-west.mp4"/></video>
 
 The prolific [Colin Moriarty](https://open.lbry.io/%40ColinsLastStand) (CLS, Sidequest, as well as podcast series Fireside Chats and now Knockback) has continued to forge his own path in games and news media with his own blend of political opinion, games criticism, and a wit that kills fluff pieces on site. He’s as no-nonsense as they come. Long form interviews, short-form reviews, and video essays on what Trump, Oprah, and reactionary thought mean for America, you’ll find no shortage of content from this IGN editor-turned-content-maverick.
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.