### PR TITLE
Mixed content weakens HTTPS fix 2

### DIFF
--- a/content/news/72-sporthocking.md
+++ b/content/news/72-sporthocking.md
@@ -16,7 +16,7 @@ In his first video, [TJ in Berlin](lbry://sporthock-berlin), Trenton “TJ” Ra
 
 ![More sporthocking](/img/news/sporthock-inline2.png)
 
-Inspired by guys freestyling tricks with homemade stools in the German city of Kiel, the Landschutz brothers designed the first Sporthocker prototype in 2006. Today, they own a Sporthocker brand, and product design company called [Salzig in Berlin, Germany](http://www.sporthocker.com/en/). They’ve travelled two European tours and hold annual events for the budding sport.
+Inspired by guys freestyling tricks with homemade stools in the German city of Kiel, the Landschutz brothers designed the first Sporthocker prototype in 2006. Today, they own a Sporthocker brand, and product design company called [Salzig in Berlin, Germany](https://www.sporthocker.com/en/). They’ve travelled two European tours and hold annual events for the budding sport.
 
 This is a sport worth checking out. See the tour of Europe today:
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.