### PR TITLE
Mixed content weakens HTTPS fix3

### DIFF
--- a/content/news/156-sidequest.md
+++ b/content/news/156-sidequest.md
@@ -8,7 +8,7 @@ Analysis is a dish best served intelligently.
 
 You’ve seen his channel [@ColinsLastStand](https://open.lbry.io/%40ColinsLastStand) make its way to LBRY. But more recently, Mr. Moriarty has returned to his roots: the games industry. This is [@Sidequest](https://open.lbry.io/%40Sidequest)
 
-<video width="100%" controls poster="http://berk.ninja/thumbnails/LTST62VsVag" src="https://spee.ch/105c776e2eba084c3381b9c8c33a3103fdcfd46d/how-nintendo-switch-dominated-2017-and.mp4"/></video>
+<video width="100%" controls poster="https://berk.ninja/thumbnails/LTST62VsVag" src="https://spee.ch/105c776e2eba084c3381b9c8c33a3103fdcfd46d/how-nintendo-switch-dominated-2017-and.mp4"/></video>
 
 After a long stint as one of the independent staple voices at IGN.com, and later joining his former comrades at Kinda Funny Games, Colin Moriarty has again reinvented his quest to speak his mind about his favorite things. On the heels of his interview last year with [@TheRubinReport](https://open.lbry.io/%40TheRubinReport) to boot!
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.