### PR TITLE
Mixed content weakens HTTPS fix4

### DIFF
--- a/content/news/151-boombust.md
+++ b/content/news/151-boombust.md
@@ -8,7 +8,7 @@ The financial cycles, bubbles, and economies of scale: they’re the mythical st
 
 And depending on who you ask, the story isn’t always the same.
 
-<video width="100%" controls poster="http://berk.ninja/thumbnails/Hnj6AQvbSls" src="https://spee.ch/8de45bc0aaa44da550b37c1e593c6fb69c34461e/disrupting-media-platforms.mp4"/></video>
+<video width="100%" controls poster="https://berk.ninja/thumbnails/Hnj6AQvbSls" src="https://spee.ch/8de45bc0aaa44da550b37c1e593c6fb69c34461e/disrupting-media-platforms.mp4"/></video>
 
 On the heel’s of the television debut of LBRY, [Boom Bust](https://open.lbry.io/%40BoomBust) joins [Redacted Tonight](https://open.lbry.io/%40RedactedTonight) as the second RT America show to land on LBRY for your post-broadcast pleasure.
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.