### PR TITLE
Mixed content weakens HTTPS fix6

### DIFF
--- a/content/news/137-nilered.md
+++ b/content/news/137-nilered.md
@@ -17,7 +17,7 @@ Rounding out the top five science channels on LBRY is perhaps the most legendary
 [@NileRed](https://open.lbry.io/%40NileRed) (also available on spee.ch at https://spee.ch/@NileRed) is a regular Reddit front page sensation. Don’t believe me? As /u/deeexz [two years ago](https://www.reddit.com/r/chemistry/comments/3lgk8f/my_absolute_favourite_chemistryrelated_channel_on/?st=j98pwzbq&sh=a9b568e6) said, “My absolute favourite chemistry-related channel on YouTube.” And now, NileRed has nearly a quarter of a million subscribers. So, we should all be thanking deeexz.
 
 Get lit on chemistry via spee.ch:
-<video width="100%" controls poster="http://berk.ninja/thumbnails/5ZrfNAHDjWU" src="https://spee.ch/1fe933b8c0709dcc035ec4df73e3b0f63ba5d112/red-phosphorus-from-matchboxes.mp4"/></video>
+<video width="100%" controls poster="https://berk.ninja/thumbnails/5ZrfNAHDjWU" src="https://spee.ch/1fe933b8c0709dcc035ec4df73e3b0f63ba5d112/red-phosphorus-from-matchboxes.mp4"/></video>
 
 Please support NileRed by tipping LBRY credits in-app to your favorite chemical reactions. And also because tipping is a pretty, pretty, prettttty cool.
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.