### PR TITLE
Mixed content weakens HTTPS fix8

### DIFF
--- a/content/news/33-zarghamjoins.md
+++ b/content/news/33-zarghamjoins.md
@@ -12,11 +12,11 @@ For those new to our project, LBRY harnesses the same blockchain technology unde
 
 Things are moving at breakneck speed...
 
-**In February, we released an alpha version of LBRY's Graphical Interface on OS X El Capitan** and [unveiled our software publicly for the first time with a live demo](https://www.youtube.com/watch?v=nu-yk5NYy1o) at [Liberty Forum 2016](http://nhlibertyforum.com) (sorry for A/V quality - we're saving money by doing all recording on a stack of spare VHS tapes from 1982).
+**In February, we released an alpha version of LBRY's Graphical Interface on OS X El Capitan** and [unveiled our software publicly for the first time with a live demo](https://www.youtube.com/watch?v=nu-yk5NYy1o) at [Liberty Forum 2016](https://nhlibertyforum.com) (sorry for A/V quality - we're saving money by doing all recording on a stack of spare VHS tapes from 1982).
 
 
 **Today, we are excited to announce the addition of data scientist Dr. Michael Zargham to the LBRY team.** Zargham is going to open up a lot of avenues for us through his intense intellect and professional associations. He’s the guy that can take complex datasets and mathematical equations and put them to practical use. He earned a Ph.D. in electrical engineering from the University of Pennsylvania and has over a decade of experience building problem-solving tools for businesses. Zargham has [more than a dozen academic papers to his credit](https://www.linkedin.com/in/mczargham), and his work has been cited extensively.
 
-**The crypto community will have an opportunity to meet the LBRY team this weekend at the [2016 MIT Bitcoin Expo](http://mitbitcoinexpo.org).** This will be our first chance to show off the LBRY platform to the community that literally built our foundation.
+**The crypto community will have an opportunity to meet the LBRY team this weekend at the [2016 MIT Bitcoin Expo](https://mitbitcoinexpo.org).** This will be our first chance to show off the LBRY platform to the community that literally built our foundation.
 
 We’re excited about connecting with our roots, but make no mistake: our mission is to grow a platform that will put cryptocurrency in every living room – whether or not users care that it’s there!


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.