### PR TITLE
Mixed content weakens HTTPS fix11

### DIFF
--- a/content/news/27-lbry-adds-chief-growth-officer-josh-finer.md
+++ b/content/news/27-lbry-adds-chief-growth-officer-josh-finer.md
@@ -12,7 +12,7 @@ We’re excited to announce that Josh Finer will be “that guy” on the LBRY t
 
 Finer’s official title is Chief Growth Officer, but we just think of him as Mr. Problem Solver.
 
-<p style="text-align: center;"><img src="http://i.imgur.com/EJxY422.jpg" alt="LBRY's Chief Growth Officer, Josh Finer"></p>
+<p style="text-align: center;"><img src="https://i.imgur.com/EJxY422.jpg" alt="LBRY's Chief Growth Officer, Josh Finer"></p>
 
 Josh is as comfortable in the suit-and-tie world of business and finance as he is in the nerdy world of computers and coding. As he put it, “Walking the line between technical and business issues is my pastime.”
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.