### PR TITLE
Mixed content weakens HTTPS fix12

### DIFF
--- a/content/news/25-huemer-joins-lbry-ethical-advisor.md
+++ b/content/news/25-huemer-joins-lbry-ethical-advisor.md
@@ -12,7 +12,7 @@ Songwriter Steve Taylor painted a grim picture of our modern day ethical landsca
 
 We might have our moments of cynicism, but we don’t buy into the ethics-free business model prevalent in the world today. That’s why we are excited to announce the addition of Professor Michael Huemer as Ethical Advisor to LBRY Inc.
 
-<p style="text-align: center;"><img src="http://i.imgur.com/VlXnnM6.png" alt="Michael Huemer joins LBRY as Ethical Advisor"></p>
+<p style="text-align: center;"><img src="https://i.imgur.com/VlXnnM6.png" alt="Michael Huemer joins LBRY as Ethical Advisor"></p>
 
 Huemer is a rising star in the world of ethical philosophy, with several books to his name and a [hit TED talk](https://www.youtube.com/watch?v=4JYL5VUe5NQ).
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.