### PR TITLE
Mixed content weakens HTTPS fix13

### DIFF
--- a/content/news/23-bravenewcoin.md
+++ b/content/news/23-bravenewcoin.md
@@ -6,15 +6,15 @@ date: '2015-12-17 21:55:57'
 
 If you haven't heard, LBRY has a little competition – Alexandria, "The People's Library". Now don't get us wrong; LBRY welcomes competition! In fact, we're enthusiastic supporters of anyone who wants to put more power in the hands of individuals by building more effective markets for information. Heck, we even engaged in some innocent crypto-flirting with Alexandria this week:
 
-<p style="text-align: center;"><img src="http://i.imgur.com/KFfWju3.png" alt="LBRY & Alexandria crypto-flirt on Twitter"></p>
+<p style="text-align: center;"><img src="https://i.imgur.com/KFfWju3.png" alt="LBRY & Alexandria crypto-flirt on Twitter"></p>
 
 Perhaps our biggest critique of Alexandria is their waste of money in buying all those vowels ;).
 
-But to the point. [BraveNewCoin published the first side-by-side comparison of LBRY and Alexandria this week](http://bravenewcoin.com/news/alexandria-vs-lbry-which-will-be-the-file-sharing-application-of-the-next-generation/). The article is thorough and fair, highlighting what we believe to be one of LBRY's strongest asset:
+But to the point. [BraveNewCoin published the first side-by-side comparison of LBRY and Alexandria this week](https://bravenewcoin.com/news/alexandria-vs-lbry-which-will-be-the-file-sharing-application-of-the-next-generation/). The article is thorough and fair, highlighting what we believe to be one of LBRY's strongest asset:
 
 >"Perhaps the most interesting difference is the naming system, which works a lot like the internet's Domain Naming System (DNS).
 
->"LBRY in much the same way you would register a domain name for your website that starts with an 'http://', in LBRY, you would register a name for each piece of content that you want to share, and those start with 'lbry://'.
+>"LBRY in much the same way you would register a domain name for your website that starts with an 'https://', in LBRY, you would register a name for each piece of content that you want to share, and those start with 'lbry://'.
 
 >"The idea is that web browsers will eventually read those links automatically so that you can simply click on an URL like 'lbry://wonderfullife'  in order to watch the movie 'It's a wonderful life.'"
 

--- a/content/news/23-bravenewcoin.md
+++ b/content/news/23-bravenewcoin.md
@@ -14,7 +14,7 @@ But to the point. [BraveNewCoin published the first side-by-side comparison of L
 
 >"Perhaps the most interesting difference is the naming system, which works a lot like the internet's Domain Naming System (DNS).
 
->"LBRY in much the same way you would register a domain name for your website that starts with an 'https://', in LBRY, you would register a name for each piece of content that you want to share, and those start with 'lbry://'.
+>"LBRY in much the same way you would register a domain name for your website that starts with an 'http://', in LBRY, you would register a name for each piece of content that you want to share, and those start with 'lbry://'.
 
 >"The idea is that web browsers will eventually read those links automatically so that you can simply click on an URL like 'lbry://wonderfullife'  in order to watch the movie 'It's a wonderful life.'"
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.