### PR TITLE
Mixed content weakens HTTPS fix15

### DIFF
--- a/content/news/19-free-lbry-credits-come-and-get-em.md
+++ b/content/news/19-free-lbry-credits-come-and-get-em.md
@@ -7,13 +7,13 @@ date: '2015-11-24 19:43:59'
 We are fast approaching the deadline to earn free LBRY credits (LBC) by being an alpha tester of the LBRY protocol. That’s right – we’re giving away 1,000 LBC to anyone who just **tries** to install LBRY, then completes our survey. [Get it here](https://lbry.io/get) and be the first on your block with LBC.
 
 A warm shoutout to Amanda Johnson, who reminded her viewers of this opportunity in the most recent regular episode of [The Daily Decrypt](https://www.youtube.com/channel/UCqNCLd2r19wpWWQE6yDLOOQ/featured).
-<p style="text-align: center;"><img src="http://i.imgur.com/rH04oCZ.png" alt="The Daily Decrypt plugs LBRY"></p>
+<p style="text-align: center;"><img src="https://i.imgur.com/rH04oCZ.png" alt="The Daily Decrypt plugs LBRY"></p>
 Here’s what she had to say:
 > "LBRY is an alpha stage protocol right now, which would make content viewable on URIs [Uniform Resource Identifier] which are not HTTP, but rather LBRY-specific URIs. Basically, combining the functionality of BitTorrent with the incentives of Bitcoin and the file storage capabilities of STRJ. They’re looking for people to try to download and use their alpha software, which has to be done from the command line. If you’re comfortable with that and you’re willing just to download it and tell them how it felt for you, they’ll give you 1,000 LBRY tokens. You just fill out a survey once you’ve completed the download process, send it back to them, and you get the bits."
 
-You may remember Amanda from her guest blog post here last month – [LBRY Gets Content Creators Out of Precarious Position](http://blog.lbry.io/lbry-gets-content-creators-out-of-precarious-position-daily-decrypts-amanda-b-johnson/).
+You may remember Amanda from her guest blog post here last month – [LBRY Gets Content Creators Out of Precarious Position](https://blog.lbry.io/lbry-gets-content-creators-out-of-precarious-position-daily-decrypts-amanda-b-johnson/).
 
-LBRY also owes a thank you to Joël Valenzuela of Liberty Upward, who wrote an article about us last week – [LBRY Leads the Decentralized Information Revolution](http://libertyupward.com/lbry-leads-the-decentralized-information-revolution/). We’re excited to watch people like Joël get excited about LBRY. Free market and blockchain enthusiasts quickly grasp the powerful but simple evolution in content distribution LBRY represents. Joël writes:
+LBRY also owes a thank you to Joël Valenzuela of Liberty Upward, who wrote an article about us last week – [LBRY Leads the Decentralized Information Revolution](https://libertyupward.com/lbry-leads-the-decentralized-information-revolution/). We’re excited to watch people like Joël get excited about LBRY. Free market and blockchain enthusiasts quickly grasp the powerful but simple evolution in content distribution LBRY represents. Joël writes:
 
 > "With LBRY, no one can stop you from publishing your content, or getting compensated. Power is exclusively in the individual’s hands.
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.