### PR TITLE
Mixed content weakens HTTPS fix17

### DIFF
--- a/content/news/15-renowned-ip-attorney-kinsella-joins-lbry-cryptoapp-as-legal-advisor.md
+++ b/content/news/15-renowned-ip-attorney-kinsella-joins-lbry-cryptoapp-as-legal-advisor.md
@@ -8,7 +8,7 @@ LBRY Inc., the startup behind a new blockchain-based content distribution platfo
 
 Stephan Kinsella has joined the executive team of LBRY Inc. as Legal Advisor, helping the company navigate the complex US and international copyright laws as they seek to radically upend the media industry.
 
-![Stephan Kinsella](http://i.imgur.com/oKoXXO2.jpg?1)
+![Stephan Kinsella](https://i.imgur.com/oKoXXO2.jpg?1)
 
 *<p style="text-align: center;">Stephan Kinsella, J.D. LL.M., Author and IP Attorney</p>*
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.