### PR TITLE
Mixed content weakens HTTPS fix18

### DIFF
--- a/content/news/14-lbry-gets-content-creators-out-of-precarious-position-daily-decrypts-amanda-b-johnson.md
+++ b/content/news/14-lbry-gets-content-creators-out-of-precarious-position-daily-decrypts-amanda-b-johnson.md
@@ -26,7 +26,7 @@ In Bitcoin, if one or a hundred or even a thousand "hosts" go offline, Bitcoin s
 
 This is what censorship-resistance looks like. As information itself becomes more integral – not only to our livelihoods but our lives – the most censorship-resistant tools will emerge as the preferable choice. The Daily Decrypt hopes to be among the first to host our content using such a tool.
 
-![Amanda](http://tracesofreality.com/wp-content/uploads/2013/09/amanda-billyrock.jpg)
+![Amanda](https://tracesofreality.com/wp-content/uploads/2013/09/amanda-billyrock.jpg)
 
 **Amanda B. Johnson** is the host of [The Daily Decrypt](https://www.youtube.com/channel/UCqNCLd2r19wpWWQE6yDLOOQ). She has written on cryptocurrencies for Bitcoin Magazine, CoinTelegraph, Bitcoin.com, and Liberty.me.
 


### PR DESCRIPTION
Mixed content weakens HTTPS
Requesting subresources using the insecure HTTP protocol weakens the security of the entire page, as these requests are vulnerable to man-in-the-middle attacks, where an attacker eavesdrops on a network connection and views or modifies the communication between two parties. Using these resources, an attacker can often take complete control over the page, not just the compromised resource.

Although many browsers report mixed content warnings to the user, by the time this happens, it is too late: the insecure requests have already been performed and the security of the page is compromised. This scenario is, unfortunately, quite common on the web, which is why browsers can't just block all mixed requests without restricting the functionality of many sites.