### PR TITLE
Added 'LBRY Community' link

### DIFF
--- a/view/template/page/learn.php
+++ b/view/template/page/learn.php
@@ -42,6 +42,9 @@
         <div class="spacer1">
           <a href="https://shop.lbry.io" class="link-primary">LBRY Merchandise Shop</a>
         </div>
+        <div class="spacer1">
+          <a href="https://lbry.community" class="link-primary" target="_blank">LBRY Community</a> (external site)
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I Added 'LBRY Community (external site)' link to 'Learn' page.
below "LBRY Merchandise Shop" on the bottom left.
I added target="_blank" to open in new tab/window

Is this okay with you? 
Or should I write a post on LBRY.io to announce LBRY Community first?
Or maybe I can do that later?

rouse