### PR TITLE
LBRY office on learn

### DIFF
--- a/view/template/page/learn.php
+++ b/view/template/page/learn.php
@@ -39,6 +39,11 @@
         <div class="spacer1">
           <a href="/credit-reports" class="link-primary"><span class="fa fa-university icon-fw"></span><span class="btn-label">Credit Reports</span></a>
         </div>
+        <h3>Our Office</h3> 
+        <div class="spacer1">
+          <a href="https://goo.gl/maps/cQfUTYHuBST2" class="link-primary"><i class="fa fa-map-marker icon-fw"></i><span class="btn-label">834 Elm Street
+Manchester, NH 03101</span></a>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26609573/44288257-d6aa9680-a299-11e8-8309-12d0d125aa9e.png)

add LBRY Office address on learn page because lbry.fund has the LBRY Office Address.. 
Open separate ticket as Mr Jeremy said on my PR earlier... 