### PR TITLE
change staging link to spee.ch instead

### DIFF
--- a/content/faq/how-to-publish.md
+++ b/content/faq/how-to-publish.md
@@ -36,7 +36,7 @@ If you don't have LBRY yet, download it [here](https://lbry.io/get).
 ![Select Channel or Anonymous](https://spee.ch/4/channel22.png)
 
 9. Type in the URL you want the content to be found under along with a minimum of 0.0001 LBC deposit for the upload (current limit, may change in the future). If you are trying to outbid a user-friendly/common URL, the system will suggest a minimum bid to take over the content at that vanity URL. There may be a delay for this takeover. Check out the `#content` channel on our [Discord chat](https://chat.lbry.io) to see this information (search for your URL). For more details regarding the URL or bid, check out our [naming document](https://lbry.io/faq/naming).
-![Video URL and Deposit](https://staging.spee.ch/6/8content-urlf.jpeg)
+![Video URL and Deposit](https://spee.ch/e/8content-urlf.jpeg)
 
 10. Next, there are selections for `Maturity`, `Language`,  and `License.` The default values are set as follows: Maturity being unchecked, which means the content is safe for all audiences, Language is set to `English`, and the License is set to `None`.  If a change is needed, click the dropdowns and select the appropriate choice. Please check the `Mature audience only` option if content is NSFW.
 ![publish](https://spee.ch/c/7-license-2-and-publish.jpeg)

--- a/content/faq/shapeshift.md
+++ b/content/faq/shapeshift.md
@@ -31,7 +31,7 @@ The ability to convert your cryptoassets into LBRY Credits (LBC) is available di
 <img src="https://spee.ch/2/convertcrypto5.JPG" width="80%" height="80%">
 
 9. Verify that LBC has been received on the **Transaction** tab under wallet. It should be updated in the transaction history.
-<img src="https://staging.spee.ch/0edaef7efc7a1ee6f51ec0ec4767cdf30b1b6916/verifr.jpeg"/>
+<img src="https://spee.ch/e4821232d4c60540e3a6889c42470ba2b7f04487/verifr.jpeg"/>
 
 10. Thanks for acquiring some LBC! 
 


### PR DESCRIPTION
staging is a speech test server, and i think it will shut down in the future, because test server. and the best use is spee.ch ( live version) and never turned off in the future.. 