### PR TITLE
fix backlink

### DIFF
--- a/content/faq/android-basics.md
+++ b/content/faq/android-basics.md
@@ -74,7 +74,7 @@ To claim any other reward, you just have to click on the round circle next to th
 
 ![claimreward](https://spee.ch/d706d5965b7befa4b1de02e71739ff5c948071c0/claim.jpg)
 
-To check whether your wallet is updated, you need to swipe your screen to show the menu bar, click on Wallet and you will see your overall updated balance. Check ![How to Backup Your Wallet](https://lbry.io/faq/how-to-backup-wallet)
+To check whether your wallet is updated, you need to swipe your screen to show the menu bar, click on Wallet and you will see your overall updated balance. Check [How to Backup Your Wallet](https://lbry.io/faq/how-to-backup-wallet)
 
 ### How To Delete Downloaded Contents On LBRY Android App. {#deletecontents}
 


### PR DESCRIPTION
![screenshot_2018-10-11-05-45-32-491](https://user-images.githubusercontent.com/26609573/46770342-1c736080-cd19-11e8-86fa-b82fcf97d65c.jpeg)
i read the faq and i saw ![blabla](link) its means image code . and it will error 404 on my device. but the better view is use baclink to the FAQ as mentioned on article
 [hacktobersfest] 