### PR TITLE
Fix markdown specific syntax

### DIFF
--- a/content/faq/how-to-publish.md
+++ b/content/faq/how-to-publish.md
@@ -23,10 +23,10 @@ If you don't have LBRY yet, download it [here](https://lbry.io/get).
 4. Enter a `Title` and `Description` for your content.
 ![choose a file](https://spee.ch/2/311-choose-file-and-others.jpeg)
 
-5. Choose a `Thumbnail`or `Thumbnail URL` for your content. The `Thumbnail URL` is a hyperlink to an image file which will serve as a preview for your content. It can be any image/GIF URL, or you can use [spee.ch](https://www.spee.ch) to host it. The default size is 800x450, but the app will scale up/down. Images uploaded directly from your local machine as `Thumbnail` will be uploaded to [spee.ch](https://www.spee.ch).
+5. Choose a `Thumbnail` or `Thumbnail URL` for your content. The `Thumbnail URL` is a hyperlink to an image file which will serve as a preview for your content. It can be any image/GIF URL, or you can use [spee.ch](https://www.spee.ch) to host it. The default size is 800x450, but the app will scale up/down. Images uploaded directly from your local machine as `Thumbnail` will be uploaded to [spee.ch](https://www.spee.ch).
 ![Choose the Thumbnail Image](https://spee.ch/6/5thumbnail.jpeg)
 
-6. Please make sure to check the option for mature audiences if your `Thumbnail`is NSFW. Otherwise just click on Upload.
+6. Please make sure to check the option for mature audiences if your `Thumbnail` is NSFW. Otherwise just click on Upload.
 ![Select the Content to Upload](https://spee.ch/6/4-thumbnail44.jpeg)
 
 7. Under the `Price`, first, determine if you want to make your content free or set a price (in USD or LBC) per view.
@@ -38,7 +38,7 @@ If you don't have LBRY yet, download it [here](https://lbry.io/get).
 9. Type in the URL you want the content to be found under along with a minimum of 0.0001 LBC deposit for the upload (current limit, may change in the future). If you are trying to outbid a user-friendly/common URL, the system will suggest a minimum bid to take over the content at that vanity URL. There may be a delay for this takeover. Check out the `#content` channel on our [Discord chat](https://chat.lbry.io) to see this information (search for your URL). For more details regarding the URL or bid, check out our [naming document](https://lbry.io/faq/naming).
 ![Video URL and Deposit](https://spee.ch/e/8content-urlf.jpeg)
 
-10. Next, there are selections for `Maturity`, `Language`,  and `License.` The default values are set as follows: Maturity being unchecked, which means the content is safe for all audiences, Language is set to `English`, and the License is set to `None`.  If a change is needed, click the dropdowns and select the appropriate choice. Please check the `Mature audience only` option if content is NSFW.
+10. Next, there are selections for `Maturity`, `Language`,  and `License`. The default values are set as follows: Maturity being unchecked, which means the content is safe for all audiences, Language is set to `English`, and the License is set to `None`.  If a change is needed, click the dropdowns and select the appropriate choice. Please check the `Mature audience only` option if content is NSFW.
 ![publish](https://spee.ch/c/7-license-2-and-publish.jpeg)
 
 11. Read and agree to the terms of service.


### PR DESCRIPTION
Added spacing after `Thumbnail` and removed a period from the inline code brackets. 

🎃