### PR TITLE
Corrected mistakes in bounty documentation pages

### DIFF
--- a/content/bounty/app-i18n.md
+++ b/content/bounty/app-i18n.md
@@ -15,4 +15,4 @@ To complete this bounty, [lbry-desktop](https://github.com/lbryio/lbry-desktop) 
 - Load and perform translation based on language settings
 - Existing component text and messaging must be wrapped in translation calls
 
-It is probably a good idea to consult with our development team on [Discord chat](https://chat.lbry.io) or via [email](mailto:hello@lbry.io) before completing this bounty in it's entirety.
+It is probably a good idea to consult with our development team on [Discord chat](https://chat.lbry.io) or via [email](mailto:hello@lbry.io) before completing this bounty in its entirety.

--- a/content/bounty/automatic-app-updates.md
+++ b/content/bounty/automatic-app-updates.md
@@ -11,7 +11,7 @@ The LBRY app currently does not update itself automatically, however electron do
 To complete this bounty, [lbry-desktop](https://github.com/lbryio/lbry-desktop) must be modified as follows:
 
 - Detect when a new latest release is available, download it and prompt the user with a "Restart LBRY" / "I'll do it later" dialog to have the update take effect.
-- Parse the changelog for the latest release, if it contains `Security` items carry out the update automatically without presenting the "I'll do it later" option.
+- Parse the changelog for the latest release. If it contains `Security` items, carry out the update automatically without presenting the "I'll do it later" option.
 - When an update begins store an update-history tracking file detailing what the version being updated is, what version it is being updated to, and when the update happened.
 - Upon starting the app after an update, alert the user that the update was successful (and note if it contained security updates), and update the history file to indicate that the update was successful.
 

--- a/content/bounty/http-support.md
+++ b/content/bounty/http-support.md
@@ -20,4 +20,4 @@ sources: {
 }
 ```
 
-The `sources` field is designed to be extended and support resolution to multiple protocols. To complete this the LBRY daemon must be modified to read `http` as a source key and use this key to access the data via HTTP (or HTTPS) when present,
+The `sources` field is designed to be extended and support resolution to multiple protocols. To complete this the LBRY daemon must be modified to read `http` as a source key and use this key to access the data via HTTP (or HTTPS) when present.

--- a/content/bounty/lbry-binding.md
+++ b/content/bounty/lbry-binding.md
@@ -10,11 +10,11 @@ When the LBRY daemon is running, it provides a set of API calls available via a 
 
 We want to make it as easy as possible to interact with LBRY in every programming language.
 
-Completing this bounty involves creating a simple library to make it as easy as possible to interact with the LBRY protocol in a language we do not already have a binding for. Ideally, this this also include the LBRYcrd api, see php example below for details.
+Completing this bounty involves creating a simple library to make it as easy as possible to interact with the LBRY protocol in a language we do not already have a binding for. Ideally, this also includes the LBRYcrd API. See php example below for details.
 
 An example of a binding can be found in the [php-api](https://github.com/lbryio/php-api) repo and the entire listing can be found on [lbry.tech](https://lbry.tech/resources/api-wrappers).
 
-A binding can typically be written using cURL in less than 100 lines of code. The repo should be well documented for the wrapper language, have install/setup instructions and tests. 
+A binding can typically be written using cURL in less than 100 lines of code. The repo should be well documented for the wrapper language and have install/setup instructions and tests. 
 
 If you are pursuing this effort, please [email us](mailto:hello@lbry.io) so we can update this bounty with the current progress. 
 

--- a/content/bounty/mining-inflation.md
+++ b/content/bounty/mining-inflation.md
@@ -10,11 +10,11 @@ LBRY Credits(LBC) are distributed via the blockchain mining process approximatel
 
 The [mining schedule](https://lbry.io/faq/block-rewards) details how these credits will be distributed. We are currently in the logarithmically decreasing phase of the mining process where, at the time of this writing (May 20, 2018), the current block reward is 359 LBC. You can find the current block reward by visiting the [explorer](https://explorer.lbry.io) page and clicking the latest block to find the first output. 
 
-The goal of this bounty is to analyze and visualize the impact of mining inflation on coin supply. The end result would be the calculation code and web embeddable supply chart. Click [here](https://www.bitcoinmining.com/how-are-new-bitcoins-created/) to find an example. At a minimum, the x-axis should display dates and the y-axis is the cumulative LBC available.     
+The goal of this bounty is to analyze and visualize the impact of mining inflation on coin supply. The end result would be the calculation code and web embeddable supply chart. Click [here](https://www.bitcoinmining.com/how-are-new-bitcoins-created/) to find an example. At minimum, the x-axis should display dates and the y-axis is the cumulative LBC available.     
 
 Hints:
 - [Sample PHP Program](https://drive.google.com/open?id=19LXPIBhZnd-SEnQlrke2tb-ZwESrbK2D) to calculate estimated block reward at any given time.
-- Use actual block times from https://explorer.lbry.io (or (Chainquery)[https://github.com/lbryio/chainquery) if it's avialable) for historical data
+- Use actual block times from https://explorer.lbry.io (or (Chainquery)[https://github.com/lbryio/chainquery) if it's available) for historical data
 
 Bonus: Overlay with circulating supply information from CoinMarketCap.com 
 

--- a/content/bounty/modified-block-explorer.md
+++ b/content/bounty/modified-block-explorer.md
@@ -10,7 +10,7 @@ LBRY currently maintains and runs a block explorer at [explorer.lbry.io/](https:
 
 This explorer is a fork of Iquidus Explorer and is [on Github](https://github.com/lbryio/lbry-explorer).
 
-Iquidus explorer is great, but does not currently support LBRY specific operations.
+Iquidus Explorer is great, but does not currently support LBRY specific operations.
 
 The explorer should be modified to:
 

--- a/content/bounty/slack-lbry-url-handler.md
+++ b/content/bounty/slack-lbry-url-handler.md
@@ -9,7 +9,7 @@ date: '2016-07-01'
 Create a script for Slackbot that will:
 
 - Use the Slack API to monitor all messages in all channels
-- Detect messages sent with LBRY URLs, e.g. `lbry://oprahbees`
+- Detect messages sent with LBRY URLs (e.g. `lbry://oprahbees`)
 - Look up LBRY URLs
 - Detect if the image resolves to a GIF/GIFV and has no license payment
 - Fetch and display the image

--- a/content/bounty/social-media-cover-images.md
+++ b/content/bounty/social-media-cover-images.md
@@ -13,5 +13,5 @@ The current background images on our [Twitter](https://twitter.com/lbryio) and [
 Candidate replacements could be either a photo or a graphic design. Either way, the image should:
 
 - Connote what LBRY is about: openness and fun
-- Be unique to LBRY or otherwise not in significant use
+- Be unique to LBRY or otherwise not be in significant use
 - Suitable for white or LBRY green (#155B4A) text on top

--- a/content/bounty/transaction-history.md
+++ b/content/bounty/transaction-history.md
@@ -7,13 +7,13 @@ pr: https://github.com/lbryio/lbry-web-ui/pull/46
 date: '2016-07-01'
 ---
 
-Add a screen showing transaction history the LBRY Browser [`lbry-web-ui`](https://github.com/lbryio/lbry-web-ui).
+Add a screen showing transaction history on the LBRY Browser [`lbry-web-ui`](https://github.com/lbryio/lbry-web-ui).
 
 The screen must:
 
 - Display past outgoing and incoming transactions
 - Link to the LBRY [block explorer](https://explorer.lbry.io) for transactions
 
-The LBRY daemon already supports an API call, `get_transaction_history` to retrieve transaction history. While running LBRY, type the following in your browser console:
+The LBRY daemon already supports an API call, `get_transaction_history`, to retrieve transaction history. While running LBRY, type the following in your browser console:
 
 `lbry.call('get_transaction_history', {}, function(response) { console.log(response); });`


### PR DESCRIPTION
Modified the documentation for the bounty information pages by resolving grammatical errors, typos, and other small errors to bring about improved readability and better user-friendliness.