### PR TITLE
Removed unused variables in Session.class.php

### DIFF
--- a/controller/Session.class.php
+++ b/controller/Session.class.php
@@ -70,7 +70,7 @@ class Session
 
     protected static function initFlashes()
     {
-        foreach (static::getNamespace(static::NAMESPACE_FLASH) as $key => $val) {
+        foreach (static::getNamespace(static::NAMESPACE_FLASH) as $key) {
             static::set($key, true, static::NAMESPACE_FLASH_REMOVE);
         }
 


### PR DESCRIPTION
Hello,

In my opinion, No $val variables are required.

Because it is not used.

What do you think of it?

Thanks.