### PR TITLE
add new redirect

### DIFF
--- a/data/redirect/permanent.yaml
+++ b/data/redirect/permanent.yaml
@@ -67,3 +67,5 @@
 /faq/proof-algorithm: https://lbry.tech/resources/pow
 /faq/regtest-setup-guide: https://lbry.tech/resources/regtest-setup
 /faq/claimtrie-implementation: https://lbry.tech/resources/lbry-claimtrie
+/faq/archive-contributing: https://lbry.tech/contribute
+


### PR DESCRIPTION
### Description

redirected /faq/archive-contributing to  https://lbry.tech/contribute. not affected to other areas.. i have been tested on my locally server


<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

