### PR TITLE
Adds support for routing to all releases

### DIFF
--- a/controller/Controller.class.php
+++ b/controller/Controller.class.php
@@ -126,9 +126,8 @@ class Controller
             }
         }
 
-        $router->any('/get/lbry.pre.{ext:c}', 'DownloadActions::executeGetAppPrereleaseRedirect');
-        $router->any('/get/lbry.{ext:c}', 'DownloadActions::executeGetAppRedirect');
-        $router->any('/get/lbrynet.{os:c}.zip', 'DownloadActions::executeGetDaemonRedirect');
+        $router->get('/releases/{repo:c}.{ext:c}', 'DownloadActions::executeDownloadReleaseAsset');
+        $router->get('/releases/pre/{repo:c}.{ext:c}', 'DownloadActions::executeDownloadPrereleaseAsset');
 
         $router->get([ContentActions::URL_NEWS . '/{slug:c}?', 'news'], 'ContentActions::executeNews');
         $router->get([ContentActions::URL_FAQ . '/{slug:c}?', 'faq'], 'ContentActions::executeFaq');

--- a/controller/action/DownloadActions.class.php
+++ b/controller/action/DownloadActions.class.php
@@ -5,26 +5,14 @@ class DownloadActions extends Actions
     //bad, fix me!
     const ANDROID_STORE_URL = 'https://play.google.com/store/apps/details?id=io.lbry.browser';
 
-    public static function executeGetAppRedirect(string $ext)
+    public static function executeDownloadPrereleaseAsset(string $repo, string $ext)
     {
-        return Controller::redirect(GitHub::getAppDownloadUrl(OS::getOsForExtension($ext)) ?: '/get', 302);
+        return static::executeDownloadReleaseAsset($repo, $ext, true);
     }
 
-    public static function executeGetAppPrereleaseRedirect(string $ext)
+    public static function executeDownloadReleaseAsset(string $repo, string $ext, bool $allowPrerelease = false)
     {
-        return Controller::redirect(GitHub::getAppPrereleaseDownloadUrl(OS::getOsForExtension($ext)) ?: '/get', 302);
-    }
-
-
-    public static function executeGetDaemonRedirect(string $os)
-    {
-        $uri  = null;
-        $oses = Os::getAll();
-
-        if (isset($oses[$os])) {
-            $uri = GitHub::getDaemonDownloadUrl($os);
-        }
-        return Controller::redirect($uri, 302);
+        return Controller::redirect(GitHub::getRepoReleaseUrl($repo, OS::getOsForExtension($ext), $allowPrerelease) ?: '/get', 302);
     }
 
     /*
@@ -48,7 +36,7 @@ class DownloadActions extends Actions
       }
       else
       {
-        $asset = Github::getAppAsset($os);
+        $asset = Github::getRepoAsset(GitHub::REPO_LBRY_DESKTOP, $os);
         $params['downloadUrl'] = $asset ? $asset['browser_download_url'] : null;
       }
 
@@ -130,7 +118,7 @@ class DownloadActions extends Actions
             list($uri, $osTitle, $osIcon, $buttonLabel, $analyticsLabel) = $osChoices[$os];
 
             if ($os !== OS::OS_ANDROID) {
-              $asset = Github::getAppAsset($os);
+              $asset = Github::getRepoAsset(GitHub::REPO_LBRY_DESKTOP, $os);
             } else {
               $asset = ['browser_download_url' => static::ANDROID_STORE_URL];
             }
@@ -158,8 +146,8 @@ class DownloadActions extends Actions
       list($uri, $osTitle, $osIcon, $buttonLabel, $analyticsLabel) = $osChoices[$os];
 
       if ($os !== OS::OS_ANDROID) {
-        $release = Github::getAppRelease();
-        $asset = Github::getAppAsset($os);
+        $release = Github::getRepoRelease(GitHub::REPO_LBRY_DESKTOP, false);
+        $asset = Github::getRepoAsset(GitHub::REPO_LBRY_DESKTOP, $os);
       } else {
         $asset = ['browser_download_url' => static::ANDROID_STORE_URL, 'size' => 0];
         $release = [];

--- a/data/redirect/permanent.yaml
+++ b/data/redirect/permanent.yaml
@@ -1,6 +1,4 @@
--- 
-/FLO: /news
-/There: /news
+--
 /art: /what
 /credit-reports/2016-Q2: /credit-reports/2016-q2
 /developer-program: /news
@@ -8,15 +6,35 @@
 /faq/Q1-17-CreditReport: /credit-reports/2017-Q1
 /faq/Q4-credit-report: /credit-reports/2016-Q4
 /faq/api-help: /faq/how-to-cli
+/faq/claimtrie-implementation: https://lbry.tech/resources/lbry-claimtrie
 /faq/contributing: https://lbry.tech/contribute
+/faq/how-to-encrypt-wallet: https://lbry.tech/resources/encrypt-lbrycrd
+/faq/how-to-report-bugs: /faq/support
 /faq/make-money: /faq/earn-income
 /faq/no-auction-options: /faq/naming
+/faq/proof-algorithm: https://lbry.tech/resources/pow
 /faq/quarterly-report-3q-2016: /credit-reports/2016-Q3
 /faq/quarterly-report-july-2016: /credit-reports/2016-Q2
+/faq/regtest-setup-guide: https://lbry.tech/resources/regtest-setup
 /faq/tips: /faq/appreciation
 /faq/when-referral-payouts: /faq/referrals
 /faq/why-care-about-lbry: /get
 /feedback: /learn
+/FLO: /news
+/get/lbry.exe : /releases/lbry-desktop.exe
+/get/lbry.msi : /releases/lbry-desktop.exe
+/get/lbry.dmg : /releases/lbry-desktop.dmg
+/get/lbry.pkg : /releases/lbry-desktop.dmg
+/get/lbry.deb : /releases/lbry-desktop.deb
+/get/lbry.pre.exe : /releases/pre/lbry-desktop.exe
+/get/lbry.pre.msi : /releases/pre/lbry-desktop.exe
+/get/lbry.pre.dmg : /releases/pre/lbry-desktop.dmg
+/get/lbry.pre.pkg : /releases/pre/lbry-desktop.dmg
+/get/lbry.pre.deb : /releases/pre/lbry-desktop.deb
+/get/lbrynet.linux.zip: /releases/lbry.deb
+/get/lbrynet.windows.zip: /releases/lbry.exe
+/get/lbrynet.macos.zip: /releases/lbry.pkg
+/get/lbrynet.osx.zip: /releases/lbry.pkg
 /get.How+to+Create+an+Identity+LBRY+TutorialsFollow: /faq/identity-requirements
 /getFree: /news/free-lbry-credits-come-and-get-em
 /join-list: /list/subscribe
@@ -25,9 +43,10 @@
 /lbry-osx-latest.dmg: /get
 /list: /list/subscribe
 /navframe?selectedItem=/news: /news
+/navframe?selectedItem=/news?selectedItem=/news: /news
 /news/$1.2b-market-cap-we-dont-care: /news/1.2b-market-cap-we-dont-care
-/news/author/jeremy: /team
 /news/author/jeremy/2: /team
+/news/author/jeremy: /team
 /news/author/jimmy-kiselak: /team
 /news/author/sam/page/2: /team
 /news/author/sam/page/3: /team
@@ -36,11 +55,10 @@
 /news/every-major-tech-company-hates-you: /news
 /news/get: /get
 /news/ios: /ios
-/news/lbry.io: /news
 /news/lbry-promo-video-raw-footage: /news
-/news/news/lbry-app-sneak-peak-big-questions-answered-lbry-on-blocktalk-last-night: /news/lbry-app-sneak-peak-big-questions-answered-lbry-on-blocktalk-last-night
+/news/lbry.io: /news
 /news/meet-the-lbry-founders: /team
-/navframe?selectedItem=/news?selectedItem=/news: /news
+/news/news/lbry-app-sneak-peak-big-questions-answered-lbry-on-blocktalk-last-night: /news/lbry-app-sneak-peak-big-questions-answered-lbry-on-blocktalk-last-night
 /news/news/meet-the-lbry-founders: /news/meet-the-lbry-founders
 /news/news/ultimate-wizard-meet-alex-grin: /news/ultimate-wizard-meet-alex-grin
 /news/page/2: /news
@@ -54,16 +72,12 @@
 /news/www.maidsafe.com: /news
 /news/www.porcfest.com: /news/lbry-at-porcfest-first-public-screening-film-via-blockchain
 /nothing-here: /news
-/press-kit.zip: /press-kit
 /participate: /faq/contributing
+/press-kit.zip: /press-kit
 /publish: /youtube
 /quickstart: https://lbry.tech/playground
 /slack: https://chat.lbry.io
+/There: /news
 /what-is-lbry: /faq/what-is-lbry
 /youtube/cdSSo: /news
 /youtube/sync: /faq/youtube
-/faq/how-to-report-bugs: /faq/support
-/faq/how-to-encrypt-wallet: https://lbry.tech/resources/encrypt-lbrycrd
-/faq/proof-algorithm: https://lbry.tech/resources/pow
-/faq/regtest-setup-guide: https://lbry.tech/resources/regtest-setup
-/faq/claimtrie-implementation: https://lbry.tech/resources/lbry-claimtrie


### PR DESCRIPTION
Fixes #871 

My biggest question is if there is a better pattern for routing than using the extension when it is inappropriate.

Currently, the dynamic route format is:

`/releases/<repo>.<ext>`

`<ext>` is then converted to an OS. GitHub release URLs are inspected and the OS of the release is determined by inspecting the content type, extension, and file name of the release.

This results in a somewhat awkward design, especially when the release is itself an archive file. E.g.:

`/releases/lbry.deb` actually downloads you `lbrynet-linux.zip`.