### PR TITLE
feat: email auto verify page

### DIFF
--- a/controller/Controller.class.php
+++ b/controller/Controller.class.php
@@ -106,6 +106,7 @@ class Controller
         $router->get('/youtube/{version}', 'AcquisitionActions::executeYouTube');
 
         $router->get('/verify/{token}', 'AcquisitionActions::executeVerify');
+        $router->get('/verify', 'AcquisitionActions::executeAutoVerify');
 
 
         $router->get('/news/category/{category}', 'ContentActions::executePostCategoryFilter');

--- a/controller/action/AcquisitionActions.class.php
+++ b/controller/action/AcquisitionActions.class.php
@@ -27,7 +27,7 @@ class AcquisitionActions extends Actions
 
         return Controller::redirect(Request::getReferrer(), 303);
     }
-      
+
     public static function executeYouTube(string $version = '')
     {
         if (isset($_GET['error_message'])) {
@@ -57,6 +57,11 @@ class AcquisitionActions extends Actions
     public static function executeVerify(string $token)
     {
         return ['acquisition/verify', ['token' => $token]];
+    }
+
+    public static function executeAutoVerify()
+    {
+        return ['acquisition/auto-verify'];
     }
 
     public static function executeYoutubeToken()

--- a/view/template/acquisition/auto-verify.php
+++ b/view/template/acquisition/auto-verify.php
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Verify Your Identity</title>
+    <link rel="icon" href="images/favicon.ico">
+    <script src='https://www.google.com/recaptcha/api.js?' async defer></script>
+    <script type="text/javascript">
+        const ENDPOINT = 'https://api.lbry.io/user_email/confirm_v2'
+
+        var verifyUser = function(email, verification_token, recaptcha) {
+            const url = `${ENDPOINT}?email=${email}&verification_token=${verification_token+"x"}&recaptcha=${recaptcha}`;
+            fetch(url)
+                .then((response) => {
+                    if (response.error) {
+                        throw Error(response.error)
+                    }
+                    document.getElementById("title").textContent = "Done!"
+                    document.getElementById("verify").style.display = "none";
+                    document.getElementById("verify-success").style.display = "block";
+                })
+                .catch(error => {
+                    document.getElementById("title").textContent = "Uh oh"
+                    document.getElementById("verify").style.display = "none";
+                    document.getElementById("verify-error").style.display = "block";
+                    document.getElementById("verify-error-text").textContent = error.message;
+                })
+        }
+
+        var verifyCallback = function(response) {
+            const urlParams = new URLSearchParams(window.location.search);
+            const email = urlParams.get('email')
+            const verification_token = urlParams.get('verification_token');
+            // In the future we will have an `origin` query, to smartly redirect (or tell users they are verified)
+            // eg. if origin == "android" and device == "android" open the app, else say "your android app is verified"
+            verifyUser(email, verification_token, response);
+
+            document.getElementById("captcha-block").style.display = "none";
+            document.getElementById("verify").style.display = "block";
+        }
+
+        var expiredCallback = function(error) {
+            console.log("expired", error)
+        }
+    </script>
+</head>
+<body>
+<div style="display: flex; align-items: center; flex-direction: column;" class="text-center">
+    <img src="/img/lbry-dark-1600x528.png" style="max-height: 80px; margin-top: 50px; margin-bottom: 38px" alt="LBRY"/>
+    <h1 id="title">Almost Done!</h1>
+    <div id="captcha-block">
+        <p>Click the captcha to continue...</p>
+        <br/>
+        <div class="g-recaptcha" data-sitekey="6LcG_z0UAAAAAKBPDBhiJU_jI9cRNRiJwcUHq95u" data-callback="verifyCallback" data-expired-callback="expiredCallback"></div>
+    </div>
+
+    <div style="display: none; margin-top: 10px;" id="verify">
+        <p>Verifying...</p>
+    </div>
+    <div style="display: none; margin-top: 10px;" id="verify-error">
+        <code id="verify-error-text"></code>
+        <p style="margin-top: 10px">There was an error. Contact help@lbry.io if this keeps happening.</p>
+    </div>
+    <div style="display: none; margin-top: 10px;" id="verify-success">
+        <p>Success! Your email is now verified in the app</p>
+    </div>
+</div>
+</body>
+</html>

--- a/view/template/acquisition/auto-verify.php
+++ b/view/template/acquisition/auto-verify.php
@@ -8,11 +8,12 @@
     <link rel="icon" href="images/favicon.ico">
     <script src='https://www.google.com/recaptcha/api.js?' async defer></script>
     <script type="text/javascript">
-        const ENDPOINT = 'https://api.lbry.io/user_email/confirm_v2'
+        const ENDPOINT = 'https://api.lbry.io/user_email/confirm'
 
-        var verifyUser = function(email, verification_token, recaptcha) {
-            const url = `${ENDPOINT}?email=${email}&verification_token=${verification_token+"x"}&recaptcha=${recaptcha}`;
+        var verifyUser = function(temporary_auth_token, email, verification_token, recaptcha) {
+            const url = `${ENDPOINT}?auth_token=${temporary_auth_token}&email=${email}&verification_token=${verification_token}&recaptcha=${recaptcha}`;
             fetch(url)
+                .then(response => response.json())
                 .then((response) => {
                     if (response.error) {
                         throw Error(response.error)
@@ -31,11 +32,12 @@
 
         var verifyCallback = function(response) {
             const urlParams = new URLSearchParams(window.location.search);
+            const temporary_auth_token = urlParams.get('auth_token');
             const email = urlParams.get('email')
             const verification_token = urlParams.get('verification_token');
             // In the future we will have an `origin` query, to smartly redirect (or tell users they are verified)
             // eg. if origin == "android" and device == "android" open the app, else say "your android app is verified"
-            verifyUser(email, verification_token, response);
+            verifyUser(temporary_auth_token, email, verification_token, response);
 
             document.getElementById("captcha-block").style.display = "none";
             document.getElementById("verify").style.display = "block";
@@ -64,7 +66,8 @@
         <p style="margin-top: 10px">There was an error. Contact help@lbry.io if this keeps happening.</p>
     </div>
     <div style="display: none; margin-top: 10px;" id="verify-success">
-        <p>Success! Your email is now verified in the app</p>
+        <p class="spacer1">Success! Your email is now verified.</p>
+        <a class="btn-primary btn-large" href="lbry://?verify">Go Back To The App</a>
     </div>
 </div>
 </body>


### PR DESCRIPTION
### Description

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

Depends on https://github.com/lbryio/internal-apis/pull/672, but I think this can be reviewed before that is merged. (The endpoint may change) 

This new page will replace the current email verification page (once all apps are using the new email verification flow). Not much is different, other than the verification now happens in the browser. We call `api.lbry.io` once a user completes the captcha.

Something I'm still unsure of is what should happen if it fails:
  - "refresh to try again"?
  - "go to your app and resend the verification email"?

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### For #559 