### PR TITLE
Fixed URL for Simple Swap

### DIFF
--- a/content/faq/exchanges.md
+++ b/content/faq/exchanges.md
@@ -21,4 +21,4 @@ We are listed on several exchanges. You can buy or sell LBRY Credits at one of t
 - [Shapeshift](https://shapeshift.io) (Requires free membership account now)
 - [Changelly](https://changelly.com/exchange/BTC/LBC/1)
 - [ChangeNow](https://changenow.io/exchange?amount=1&from=btc&to=lbc)
-- [Simple Swap](https://www.simpleswap.io/)
+- [Simple Swap](https://simpleswap.io/)


### PR DESCRIPTION
### Description

Currently the entry for SimpleSwap has www. in front of it. The site doesn't work with www. in front of it because of an SSL misconfiguration on their end.

### Fixes #

Removed www.