### PR TITLE
Fix typo in example settings file (peer_port rather than peer:port)

### DIFF
--- a/content/faq/how-to-change-port.md
+++ b/content/faq/how-to-change-port.md
@@ -12,7 +12,7 @@ The most user friendly way to change the port permanently is to append the below
 Sample daemon_settings.yml (may vary by OS):   
 
     {download_directory: c:\users\lbry,
-    peer:port: 3334}
+    peer_port: 3334}
 
 ## Other Methods  
 To change the port once during runtime, set the LBRY_PEER_PORT env variable. Here's one way to do this:


### PR DESCRIPTION
### Description
Noticed a typo in the [How to change default daemon port?](https://lbry.io/faq/how-to-change-port) article. The example `daemon_settings.yml` file it provides is incorrect: 

    {download_directory: c:\users\lbry,
    peer:port: 3334}

It should say `peer_port` rather than `peer:port`. A bit of an annoying typo considering LBRY fails to start because of it. :)