### PR TITLE
Added information about close to system tray

### DIFF
--- a/content/faq/backup-data.md
+++ b/content/faq/backup-data.md
@@ -23,7 +23,7 @@ To summarize, the main directories to consider when backing up or migrating a LB
 
 ### How do I migrate all LBRY related data to a new installation?
 
-1. Install [LBRY](https://lbry.io/get) onto the target PC. Close LBRY after the initial startup
+1. Install [LBRY](https://lbry.io/get) onto the target PC. Close LBRY after the initial startup. LBRY minimizes to the system tray by defailt, so make sure that is is completely closed.
 2. Copy the `lbrynet` folder from the previous section into the appropriate [location](https://lbry.io/faq/lbry-directories) on your new installation.
 3. Copy the `lbryum` folder from the previous section into the appropriate [location](https://lbry.io/faq/lbry-directories) on your new installation.
 4. Copy your LBRY Downloads from the previous section into the appropriate location.


### PR DESCRIPTION
When I tried to restore my backed up data, it didn't work until someone mentioned the fact that LBRY minimizes to the system tray when ti tell it to close. Decided to add it here to help others.

### Description

<!-- Please describe what the changes are made in this pull request and why the change was necessary. -->

<!--
Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->
### Fixes #